### PR TITLE
fix(NetBox 3.3): Fix Imports to fix Netbox Startup on Netbox V3.3

### DIFF
--- a/nb_service/api/serializers.py
+++ b/nb_service/api/serializers.py
@@ -13,7 +13,13 @@ class MyModel1Serializer(ModelSerializer):
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
-from netbox.api import ChoiceField, ContentTypeField, WritableNestedSerializer
+NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+if NETBOX_CURRENT_VERSION >= version.parse("3.3") :
+    from netbox.api.fields import ChoiceField, ContentTypeField
+    from netbox.api.serializers import WritableNestedSerializer
+else:
+    from netbox.api import ChoiceField, ContentTypeField, WritableNestedSerializer
+
 from utilities.api import get_serializer_for_model
 from tenancy.api.nested_serializers import NestedTenantSerializer
 from ipam.choices import ServiceProtocolChoices

--- a/nb_service/api/serializers.py
+++ b/nb_service/api/serializers.py
@@ -14,13 +14,9 @@ from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
 
-from django.conf import settings
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
-if NETBOX_CURRENT_VERSION >= version.parse("3.3") :
-    from netbox.api.fields import ChoiceField, ContentTypeField
-    from netbox.api.serializers import WritableNestedSerializer
-else:
-    from netbox.api import ChoiceField, ContentTypeField, WritableNestedSerializer
+
+from netbox.api.fields import ChoiceField, ContentTypeField
+from netbox.api.serializers import WritableNestedSerializer
 
 from utilities.api import get_serializer_for_model
 from tenancy.api.nested_serializers import NestedTenantSerializer

--- a/nb_service/api/serializers.py
+++ b/nb_service/api/serializers.py
@@ -13,6 +13,8 @@ class MyModel1Serializer(ModelSerializer):
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
+
+from django.conf import settings
 NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
 if NETBOX_CURRENT_VERSION >= version.parse("3.3") :
     from netbox.api.fields import ChoiceField, ContentTypeField

--- a/nb_service/api/urls.py
+++ b/nb_service/api/urls.py
@@ -12,9 +12,11 @@ from django.conf import settings
 from packaging import version
 
 NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
-if NETBOX_CURRENT_VERSION >= version.parse("3.2") :
+if NETBOX_CURRENT_VERSION >= version.parse("3.3") :
+    from netbox.api.routers import NetBoxRouter
+elif NETBOX_CURRENT_VERSION >= version.parse("3.2") :
     from netbox.api import NetBoxRouter
-else: 
+else:
     from netbox.api import OrderedDefaultRouter as NetBoxRouter
 
 from . import views


### PR DESCRIPTION
This PR adds support for Netbox V3.3 which has issues with importing from netbox.api directly and you need to import from thre submodules.

WARNING
Okay, so I haven't written any NetBox plugins, and this seems to be working, however I don't know if anything is broken, but it is successfully starting up and seems to be able to list and create resources.

