### PR TITLE
Use new version identifier from Netbox

### DIFF
--- a/nb_service/urls.py
+++ b/nb_service/urls.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from packaging import version
 
 
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+NETBOX_CURRENT_VERSION = version.parse(settings.RELEASE.version)
 
 
 from . import views


### PR DESCRIPTION
Netbox changed the version identifiers in https://github.com/netbox-community/netbox/issues/15908